### PR TITLE
Add editing and ban actions for contacts with pagination

### DIFF
--- a/backend/src/controllers/contacts.controller.js
+++ b/backend/src/controllers/contacts.controller.js
@@ -2,7 +2,13 @@ const contactsService = require('../services/contacts.service');
 
 exports.getContacts = async (req, res) => {
   try {
-    const contacts = await contactsService.getContacts();
+    const { page, limit, search, status } = req.query;
+    const contacts = await contactsService.getContacts({
+      page: Number(page) || 1,
+      limit: Number(limit) || 10,
+      search,
+      status,
+    });
     res.json(contacts);
   } catch (err) {
     res.status(500).json({ error: 'Internal server error' });
@@ -11,9 +17,37 @@ exports.getContacts = async (req, res) => {
 
 exports.createContact = async (req, res) => {
   try {
+    const { name, email, phone } = req.body;
+    if (!name || !email || !phone) {
+      return res.status(400).json({ error: 'Missing required fields' });
+    }
     const contact = await contactsService.createContact(req.body);
     res.status(201).json(contact);
   } catch (err) {
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+exports.updateContact = async (req, res) => {
+  try {
+    const contact = await contactsService.updateContact(req.params.id, req.body);
+    res.json(contact);
+  } catch (err) {
+    if (err.code === 'P2025') {
+      return res.status(404).json({ error: 'Contact not found' });
+    }
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+exports.banContact = async (req, res) => {
+  try {
+    const contact = await contactsService.banContact(req.params.id);
+    res.json(contact);
+  } catch (err) {
+    if (err.code === 'P2025') {
+      return res.status(404).json({ error: 'Contact not found' });
+    }
     res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/backend/src/repositories/contact.repository.js
+++ b/backend/src/repositories/contact.repository.js
@@ -1,12 +1,37 @@
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
 
-exports.getContacts = async () => {
-  return await prisma.contact.findMany();
+exports.getContacts = async ({ page = 1, limit = 10, search, status } = {}) => {
+  const where = {};
+  if (search) {
+    where.OR = [
+      { name: { contains: search, mode: 'insensitive' } },
+      { email: { contains: search, mode: 'insensitive' } },
+    ];
+  }
+  if (status) {
+    where.status = status;
+  }
+  const skip = (page - 1) * limit;
+  return await prisma.contact.findMany({ where, skip, take: limit });
 };
 
 exports.createContact = async (data) => {
   return await prisma.contact.create({
     data,
+  });
+};
+
+exports.updateContact = async (id, data) => {
+  return await prisma.contact.update({
+    where: { id },
+    data,
+  });
+};
+
+exports.banContact = async (id) => {
+  return await prisma.contact.update({
+    where: { id },
+    data: { status: 'BANNED' },
   });
 };

--- a/backend/src/routes/contacts.routes.js
+++ b/backend/src/routes/contacts.routes.js
@@ -19,4 +19,18 @@ router.post(
   contactsController.createContact
 );
 
+router.put(
+  '/:id',
+  authenticate,
+  authorize(['MODERATOR', 'ADMIN']),
+  contactsController.updateContact
+);
+
+router.patch(
+  '/:id/ban',
+  authenticate,
+  authorize(['MODERATOR', 'ADMIN']),
+  contactsController.banContact
+);
+
 module.exports = router;

--- a/backend/src/services/contacts.service.js
+++ b/backend/src/services/contacts.service.js
@@ -1,9 +1,17 @@
 const contactRepository = require('../repositories/contact.repository');
 
-exports.getContacts = async () => {
-  return await contactRepository.getContacts();
+exports.getContacts = async (options) => {
+  return await contactRepository.getContacts(options);
 };
 
 exports.createContact = async (data) => {
   return await contactRepository.createContact(data);
+};
+
+exports.updateContact = async (id, data) => {
+  return await contactRepository.updateContact(id, data);
+};
+
+exports.banContact = async (id) => {
+  return await contactRepository.banContact(id);
 };


### PR DESCRIPTION
## Summary
- implement pagination and filtering in contacts repository/service
- add update and ban operations to contacts service and controller
- expose PUT /contacts/:id and PATCH /contacts/:id/ban routes

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_684922bce1008322bd7d677332b11bc5