### PR TITLE
Add validation schemas with zod

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "eslint": "^9.28.0",

--- a/backend/src/middlewares/validation.middleware.js
+++ b/backend/src/middlewares/validation.middleware.js
@@ -1,0 +1,10 @@
+const validate = (schema) => (req, res, next) => {
+  const result = schema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ errors: result.error.flatten() });
+  }
+  req.body = result.data;
+  next();
+};
+
+module.exports = validate;

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const authController = require('../controllers/auth.controller');
+const validate = require('../middlewares/validation.middleware');
+const { loginSchema } = require('../schemas/auth.schema');
 
-router.post('/login', authController.login);
+router.post('/login', validate(loginSchema), authController.login);
 
 module.exports = router;

--- a/backend/src/routes/contacts.routes.js
+++ b/backend/src/routes/contacts.routes.js
@@ -2,6 +2,8 @@ const express = require('express');
 const authenticate = require('../middlewares/authenticate.middleware');
 const authorize = require('../middlewares/authorize.middleware');
 const contactsController = require('../controllers/contacts.controller');
+const validate = require('../middlewares/validation.middleware');
+const { createContactSchema } = require('../schemas/contact.schema');
 
 const router = express.Router();
 
@@ -16,6 +18,7 @@ router.post(
   '/',
   authenticate,
   authorize(['MODERATOR', 'ADMIN']),
+  validate(createContactSchema),
   contactsController.createContact
 );
 

--- a/backend/src/schemas/auth.schema.js
+++ b/backend/src/schemas/auth.schema.js
@@ -1,0 +1,8 @@
+const { z } = require('zod');
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+module.exports = { loginSchema };

--- a/backend/src/schemas/contact.schema.js
+++ b/backend/src/schemas/contact.schema.js
@@ -1,0 +1,10 @@
+const { z } = require('zod');
+
+const createContactSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  phone: z.string().min(1),
+  photoUrl: z.string().url().optional(),
+});
+
+module.exports = { createContactSchema };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "next": "15.3.3",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { loginSchema } from '../validation/auth';
 import { useAuth } from '../context/AuthContext';
 import { useRouter } from 'next/navigation';
 
@@ -18,6 +19,13 @@ export default function LoginPage() {
 
     setIsLoading(true);
     setError('');
+
+    const result = loginSchema.safeParse({ email, password });
+    if (!result.success) {
+      setIsLoading(false);
+      setError(result.error.errors.map((err) => err.message).join(', '));
+      return;
+    }
 
     try {
       const response = await fetch('http://localhost:3000/auth/login', {

--- a/src/app/validation/auth.ts
+++ b/src/app/validation/auth.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+export type LoginData = z.infer<typeof loginSchema>;

--- a/src/app/validation/contact.ts
+++ b/src/app/validation/contact.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const contactSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  phone: z.string().min(1),
+  photoUrl: z.string().url().optional(),
+});
+
+export type ContactInput = z.infer<typeof contactSchema>;


### PR DESCRIPTION
## Summary
- install zod dependencies in both packages
- create backend validation middleware and schemas
- enforce validation on `/auth/login` and `/contacts` endpoints
- validate login form on the frontend using the same schema

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684922c28b108322bcbf1da879b7ae98