### PR TITLE
Add audit logging and winston-based logger

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const logger = require('./utils/logger');
 
 const app = express();
 
@@ -8,6 +9,12 @@ app.use(cors({
   origin: 'http://localhost:3001',
 }));
 app.use(express.json());
+
+// Log each request
+app.use((req, res, next) => {
+  logger.info(`${req.method} ${req.originalUrl}`);
+  next();
+});
 
 // Aquí vas a importar las rutas
 const authRoutes = require('./routes/auth.routes');

--- a/backend/src/controllers/audit.controller.js
+++ b/backend/src/controllers/audit.controller.js
@@ -1,0 +1,12 @@
+const auditService = require('../services/audit.service');
+const logger = require('../utils/logger');
+
+exports.getLogs = async (req, res) => {
+  try {
+    const logs = await auditService.getLogs();
+    res.json(logs);
+  } catch (err) {
+    logger.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -1,4 +1,5 @@
 const authService = require('../services/auth.service');
+const logger = require('../utils/logger');
 
 exports.login = async (req, res) => {
   try {
@@ -6,6 +7,7 @@ exports.login = async (req, res) => {
     const token = await authService.login(email, password);
     res.json({ token });
   } catch (error) {
+    logger.error(error);
     res.status(401).json({ error: error.message });
   }
 };

--- a/backend/src/controllers/contacts.controller.js
+++ b/backend/src/controllers/contacts.controller.js
@@ -1,19 +1,46 @@
 const contactsService = require('../services/contacts.service');
+const logger = require('../utils/logger');
 
 exports.getContacts = async (req, res) => {
   try {
     const contacts = await contactsService.getContacts();
     res.json(contacts);
   } catch (err) {
+    logger.error(err);
     res.status(500).json({ error: 'Internal server error' });
   }
 };
 
 exports.createContact = async (req, res) => {
   try {
-    const contact = await contactsService.createContact(req.body);
+    const contact = await contactsService.createContact(req.body, req.user.id);
     res.status(201).json(contact);
   } catch (err) {
+    logger.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+exports.updateContact = async (req, res) => {
+  try {
+    const contact = await contactsService.updateContact(
+      req.params.id,
+      req.body,
+      req.user.id
+    );
+    res.json(contact);
+  } catch (err) {
+    logger.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+exports.banContact = async (req, res) => {
+  try {
+    const contact = await contactsService.banContact(req.params.id, req.user.id);
+    res.json(contact);
+  } catch (err) {
+    logger.error(err);
     res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/backend/src/repositories/audit.repository.js
+++ b/backend/src/repositories/audit.repository.js
@@ -1,0 +1,10 @@
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+exports.createLog = async (data) => {
+  return await prisma.auditLog.create({ data });
+};
+
+exports.getLogs = async () => {
+  return await prisma.auditLog.findMany({ orderBy: { timestamp: 'desc' } });
+};

--- a/backend/src/repositories/contact.repository.js
+++ b/backend/src/repositories/contact.repository.js
@@ -10,3 +10,10 @@ exports.createContact = async (data) => {
     data,
   });
 };
+
+exports.updateContact = async (id, data) => {
+  return await prisma.contact.update({
+    where: { id },
+    data,
+  });
+};

--- a/backend/src/routes/audit.routes.js
+++ b/backend/src/routes/audit.routes.js
@@ -1,8 +1,15 @@
 const express = require('express');
+const authenticate = require('../middlewares/authenticate.middleware');
+const authorize = require('../middlewares/authorize.middleware');
+const auditController = require('../controllers/audit.controller');
+
 const router = express.Router();
 
-router.get('/test', (req, res) => {
-  res.json({ message: 'Audit log route works' });
-});
+router.get(
+  '/',
+  authenticate,
+  authorize(['ADMIN']),
+  auditController.getLogs
+);
 
 module.exports = router;

--- a/backend/src/routes/contacts.routes.js
+++ b/backend/src/routes/contacts.routes.js
@@ -19,4 +19,18 @@ router.post(
   contactsController.createContact
 );
 
+router.put(
+  '/:id',
+  authenticate,
+  authorize(['MODERATOR', 'ADMIN']),
+  contactsController.updateContact
+);
+
+router.post(
+  '/:id/ban',
+  authenticate,
+  authorize(['MODERATOR', 'ADMIN']),
+  contactsController.banContact
+);
+
 module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,7 +1,8 @@
 const app = require('./app');
+const logger = require('./utils/logger');
 
 const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
+  logger.info(`Server running on port ${PORT}`);
 });

--- a/backend/src/services/audit.service.js
+++ b/backend/src/services/audit.service.js
@@ -1,0 +1,9 @@
+const auditRepository = require('../repositories/audit.repository');
+
+exports.logAction = async (action, entity, entityId, changedById) => {
+  return await auditRepository.createLog({ action, entity, entityId, changedById });
+};
+
+exports.getLogs = async () => {
+  return await auditRepository.getLogs();
+};

--- a/backend/src/services/contacts.service.js
+++ b/backend/src/services/contacts.service.js
@@ -1,9 +1,24 @@
 const contactRepository = require('../repositories/contact.repository');
+const auditService = require('./audit.service');
 
 exports.getContacts = async () => {
   return await contactRepository.getContacts();
 };
 
-exports.createContact = async (data) => {
-  return await contactRepository.createContact(data);
+exports.createContact = async (data, userId) => {
+  const contact = await contactRepository.createContact(data);
+  await auditService.logAction('CREATE', 'Contact', contact.id, userId);
+  return contact;
+};
+
+exports.updateContact = async (id, data, userId) => {
+  const contact = await contactRepository.updateContact(id, data);
+  await auditService.logAction('UPDATE', 'Contact', contact.id, userId);
+  return contact;
+};
+
+exports.banContact = async (id, userId) => {
+  const contact = await contactRepository.updateContact(id, { status: 'BANNED' });
+  await auditService.logAction('BAN', 'Contact', contact.id, userId);
+  return contact;
 };

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -1,0 +1,26 @@
+let winston;
+try {
+  winston = require('winston');
+} catch (err) {
+  winston = null;
+}
+
+let logger;
+if (winston) {
+  logger = winston.createLogger({
+    level: 'info',
+    transports: [
+      new winston.transports.Console({
+        format: winston.format.simple(),
+      }),
+    ],
+  });
+} else {
+  logger = {
+    info: console.log,
+    error: console.error,
+    warn: console.warn,
+  };
+}
+
+module.exports = logger;


### PR DESCRIPTION
## Summary
- introduce simple winston logger fallback
- log every request and server startup
- add audit log repository, service and controller
- log contact create/update/ban actions
- expose protected `/audit-log` route
- extend contact routes with update and ban operations

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_684922ca1d0883229a467ddd3b162b3b