### PR TITLE
Integrate Sentry and OpenTelemetry

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,13 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "@sentry/node": "^7.96.0",
+    "@sentry/profiling-node": "^7.96.0",
+    "@opentelemetry/sdk-node": "^0.50.0",
+    "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.50.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.50.0"
   },
   "devDependencies": {
     "eslint": "^9.28.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,8 +1,19 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const Sentry = require('@sentry/node');
+const { ProfilingIntegration } = require('@sentry/profiling-node');
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  integrations: [new ProfilingIntegration()],
+  tracesSampleRate: 1.0,
+});
 
 const app = express();
+
+app.use(Sentry.Handlers.requestHandler());
+app.use(Sentry.Handlers.tracingHandler());
 
 app.use(cors({
   origin: 'http://localhost:3001',
@@ -17,5 +28,7 @@ const auditRoutes = require('./routes/audit.routes');
 app.use('/auth', authRoutes);
 app.use('/contacts', contactsRoutes);
 app.use('/audit-log', auditRoutes);
+
+app.use(Sentry.Handlers.errorHandler());
 
 module.exports = app;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,3 +1,4 @@
+require('./tracing');
 const app = require('./app');
 
 const PORT = process.env.PORT || 3000;

--- a/backend/src/tracing.js
+++ b/backend/src/tracing.js
@@ -1,0 +1,25 @@
+const { NodeSDK } = require('@opentelemetry/sdk-node');
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
+const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
+
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
+
+const traceExporter = new OTLPTraceExporter();
+
+const sdk = new NodeSDK({
+  traceExporter,
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+sdk.start()
+  .then(() => console.log('OpenTelemetry initialized'))
+  .catch((err) => console.log('Error initializing OpenTelemetry', err));
+
+process.on('SIGTERM', () => {
+  sdk.shutdown()
+    .then(() => console.log('OpenTelemetry terminated'))
+    .catch((err) => console.log('Error terminating OpenTelemetry', err))
+    .finally(() => process.exit(0));
+});
+

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
+import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   /* config options here */
 };
 
-export default nextConfig;
+export default withSentryConfig(nextConfig);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "next": "15.3.3",
+    "@sentry/nextjs": "^7.96.0"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: 1.0,
+});
+

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+});
+


### PR DESCRIPTION
## Summary
- capture errors in Next.js with Sentry
- wire Next.js config with Sentry
- capture backend errors with Sentry
- bootstrap OpenTelemetry for backend traces

## Testing
- `npm run lint` *(fails: next not found)*
- `npm --prefix backend test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684922d567ec83228be7478c3881c7e1