### PR TITLE
Add Swagger docs and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,49 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# grandvalira-repositorio
 
-## Getting Started
+Repositorio que contiene el frontend en Next.js y el backend en Express.
 
-First, run the development server:
+## Requisitos
+- Node.js 18 o superior
+- Una base de datos PostgreSQL
+
+## Instalación del Backend
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+cd backend
+npm install
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Crea un archivo `.env` con las siguientes variables:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```env
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE"
+JWT_SECRET="clave_secreta"
+PORT=3000 # opcional
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Ejecuta las migraciones de Prisma y genera el cliente:
 
-## Learn More
+```bash
+npx prisma migrate deploy # o npx prisma migrate dev para desarrollo
+npx prisma generate
+```
 
-To learn more about Next.js, take a look at the following resources:
+Inicia el servidor:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+node src/server.js
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+La documentación Swagger estará disponible en [http://localhost:3000/api-docs](http://localhost:3000/api-docs).
 
-## Deploy on Vercel
+## Instalación del Frontend
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Desde la raíz del proyecto ejecuta:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-# grandvalira-repositorio
+```bash
+npm install
+npm run dev
+```
+
+El frontend se abrirá en [http://localhost:3001](http://localhost:3001).
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,9 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.1.0"
   },
   "devDependencies": {
     "eslint": "^9.28.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,6 +1,8 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const swaggerUi = require('swagger-ui-express');
+const swaggerSpec = require('./swagger');
 
 const app = express();
 
@@ -17,5 +19,6 @@ const auditRoutes = require('./routes/audit.routes');
 app.use('/auth', authRoutes);
 app.use('/contacts', contactsRoutes);
 app.use('/audit-log', auditRoutes);
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 module.exports = app;

--- a/backend/src/routes/audit.routes.js
+++ b/backend/src/routes/audit.routes.js
@@ -1,6 +1,16 @@
 const express = require('express');
 const router = express.Router();
 
+/**
+ * @swagger
+ * /audit-log/test:
+ *   get:
+ *     summary: Ruta de prueba para el log de auditoría
+ *     responses:
+ *       200:
+ *         description: Respuesta de prueba
+ */
+
 router.get('/test', (req, res) => {
   res.json({ message: 'Audit log route works' });
 });

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -2,6 +2,29 @@ const express = require('express');
 const router = express.Router();
 const authController = require('../controllers/auth.controller');
 
+/**
+ * @swagger
+ * /auth/login:
+ *   post:
+ *     summary: Inicia sesión y devuelve un token
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Token de acceso
+ *       401:
+ *         description: Credenciales inválidas
+ */
+
 router.post('/login', authController.login);
 
 module.exports = router;

--- a/backend/src/routes/contacts.routes.js
+++ b/backend/src/routes/contacts.routes.js
@@ -1,4 +1,34 @@
 const express = require('express');
+
+/**
+ * @swagger
+ * /contacts:
+ *   get:
+ *     summary: Obtener todos los contactos
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de contactos
+ *   post:
+ *     summary: Crear un contacto
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               email:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Contacto creado
+ */
 const authenticate = require('../middlewares/authenticate.middleware');
 const authorize = require('../middlewares/authorize.middleware');
 const contactsController = require('../controllers/contacts.controller');

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -1,0 +1,23 @@
+const swaggerJSDoc = require('swagger-jsdoc');
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Grandvalira API',
+      version: '1.0.0',
+    },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+        },
+      },
+    },
+    security: [{ bearerAuth: [] }],
+  },
+  apis: ['./src/routes/*.js'],
+};
+
+module.exports = swaggerJSDoc(options);


### PR DESCRIPTION
## Summary
- document backend and frontend setup
- list required `.env` variables
- explain Prisma migration commands
- add swagger-ui and swagger-jsdoc integration
- document API routes with Swagger comments

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_684922dbbfe08322bb883646ef5cb099