### PR TITLE
Fix swagger configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ npx prisma migrate dev --name init
 # Ejecutar servidor
 npm run dev
 
+# Swagger UI
+# Abre http://localhost:3000/api-docs para ver la documentación
+
 # Frontend 
 
 cd app

--- a/backend/src/config/swagger.js
+++ b/backend/src/config/swagger.js
@@ -1,4 +1,5 @@
 const swaggerJsdoc = require('swagger-jsdoc');
+const path = require('path');
 
 const options = {
   definition: {
@@ -24,7 +25,8 @@ const options = {
     },
     security: [{ bearerAuth: [] }],
   },
-  apis: ['./src/routes/*.js'], // 👈 lee tus rutas
+  // Use an absolute path so swagger-jsdoc works regardless of cwd
+  apis: [path.join(__dirname, '../routes/*.js')],
 };
 
 const swaggerSpec = swaggerJsdoc(options);


### PR DESCRIPTION
## Summary
- ensure swagger-jsdoc can always find route files
- document Swagger URL in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68491e48b3c48322b71e8e273da40456