### PR TITLE
Add global Express error handling

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const swaggerUi = require('swagger-ui-express');
 const swaggerSpec = require('./config/swagger');
+const errorHandler = require('./middlewares/errorHandler');
 
 const app = express();
 
@@ -30,5 +31,7 @@ const auditRoutes = require('./routes/audit.routes');
 app.use('/auth', authRoutes);
 app.use('/contacts', contactsRoutes);
 app.use('/audit-log', auditRoutes);
+
+app.use(errorHandler);
 
 module.exports = app;

--- a/backend/src/controllers/audit.controller.js
+++ b/backend/src/controllers/audit.controller.js
@@ -1,12 +1,12 @@
 const auditService = require('../services/audit.service');
 const logger = require('../utils/logger');
 
-exports.getLogs = async (req, res) => {
+exports.getLogs = async (req, res, next) => {
   try {
     const logs = await auditService.getLogs();
     res.json(logs);
   } catch (err) {
     logger.error(err);
-    res.status(500).json({ error: 'Internal server error' });
+    next(err);
   }
 };

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -1,13 +1,14 @@
 const authService = require('../services/auth.service');
 const logger = require('../utils/logger');
 
-exports.login = async (req, res) => {
+exports.login = async (req, res, next) => {
   try {
     const { email, password } = req.body;
     const token = await authService.login(email, password);
     res.json({ token });
   } catch (error) {
     logger.error(error);
-    res.status(401).json({ error: error.message });
+    error.statusCode = 401;
+    next(error);
   }
 };

--- a/backend/src/controllers/contacts.controller.js
+++ b/backend/src/controllers/contacts.controller.js
@@ -1,7 +1,7 @@
 const contactsService = require('../services/contacts.service');
 const logger = require('../utils/logger');
 
-exports.getContacts = async (req, res) => {
+exports.getContacts = async (req, res, next) => {
   try {
     const { page, limit, search, status } = req.query;
     const contacts = await contactsService.getContacts({
@@ -13,11 +13,11 @@ exports.getContacts = async (req, res) => {
     res.json(contacts);
   } catch (err) {
     logger.error(err);
-    res.status(500).json({ error: 'Internal server error' });
+    next(err);
   }
 };
 
-exports.createContact = async (req, res) => {
+exports.createContact = async (req, res, next) => {
   try {
     const { name, email, phone } = req.body;
     if (!name || !email || !phone) {
@@ -27,11 +27,11 @@ exports.createContact = async (req, res) => {
     res.status(201).json(contact);
   } catch (err) {
     logger.error(err);
-    res.status(500).json({ error: 'Internal server error' });
+    next(err);
   }
 };
 
-exports.updateContact = async (req, res) => {
+exports.updateContact = async (req, res, next) => {
   try {
     const contact = await contactsService.updateContact(
       req.params.id,
@@ -41,21 +41,21 @@ exports.updateContact = async (req, res) => {
     res.json(contact);
   } catch (err) {
     logger.error(err);
-    res.status(500).json({ error: 'Internal server error' });
+    next(err);
   }
 };
 
-exports.banContact = async (req, res) => {
+exports.banContact = async (req, res, next) => {
   try {
     const contact = await contactsService.banContact(req.params.id, req.user.id);
     res.json(contact);
   } catch (err) {
     logger.error(err);
-    res.status(500).json({ error: 'Internal server error' });
+    next(err);
   }
 };
 
-exports.updateContact = async (req, res) => {
+exports.updateContact = async (req, res, next) => {
   try {
     const contact = await contactsService.updateContact(req.params.id, req.body);
     res.json(contact);
@@ -63,11 +63,11 @@ exports.updateContact = async (req, res) => {
     if (err.code === 'P2025') {
       return res.status(404).json({ error: 'Contact not found' });
     }
-    res.status(500).json({ error: 'Internal server error' });
+    next(err);
   }
 };
 
-exports.banContact = async (req, res) => {
+exports.banContact = async (req, res, next) => {
   try {
     const contact = await contactsService.banContact(req.params.id);
     res.json(contact);
@@ -75,6 +75,6 @@ exports.banContact = async (req, res) => {
     if (err.code === 'P2025') {
       return res.status(404).json({ error: 'Contact not found' });
     }
-    res.status(500).json({ error: 'Internal server error' });
+    next(err);
   }
 };

--- a/backend/src/middlewares/errorHandler.js
+++ b/backend/src/middlewares/errorHandler.js
@@ -1,0 +1,10 @@
+const logger = require('../utils/logger');
+
+function errorHandler(err, req, res, next) {
+  logger.error(err);
+  const statusCode = err.statusCode || 500;
+  const message = err.message || 'Internal server error';
+  res.status(statusCode).json({ error: message });
+}
+
+module.exports = errorHandler;


### PR DESCRIPTION
## Summary
- implement centralized error handler middleware for the backend API
- register the middleware in `app.js`
- use `next(err)` pattern across controllers for errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68492a324cd88322a27f2e6fafef9668