### PR TITLE
Add audit logging middleware

### DIFF
--- a/backend/src/middlewares/audit.middleware.js
+++ b/backend/src/middlewares/audit.middleware.js
@@ -1,0 +1,21 @@
+const auditService = require('../services/audit.service');
+const logger = require('../utils/logger');
+
+module.exports = (action, entity) => {
+  return (req, res, next) => {
+    const originalJson = res.json.bind(res);
+    res.json = async (data) => {
+      try {
+        const entityId = data && data.id ? data.id : req.params.id;
+        const userId = req.user && req.user.id;
+        if (entityId && userId) {
+          await auditService.logAction(action, entity, entityId, userId);
+        }
+      } catch (err) {
+        logger.error(err);
+      }
+      return originalJson(data);
+    };
+    next();
+  };
+};

--- a/backend/src/routes/contacts.routes.js
+++ b/backend/src/routes/contacts.routes.js
@@ -3,6 +3,7 @@ const authenticate = require('../middlewares/authenticate');
 const authorize = require('../middlewares/authorize.middleware');
 const contactsController = require('../controllers/contacts.controller');
 const validate = require('../middlewares/validation.middleware');
+const audit = require('../middlewares/audit.middleware');
 const { createContactSchema } = require('../schemas/contact.schema');
 
 const router = express.Router();
@@ -19,6 +20,7 @@ router.post(
   authenticate,
   authorize(['MODERATOR', 'ADMIN']),
   validate(createContactSchema),
+  audit('CREATE', 'Contact'),
   contactsController.createContact
 );
 
@@ -26,6 +28,7 @@ router.put(
   '/:id',
   authenticate,
   authorize(['MODERATOR', 'ADMIN']),
+  audit('UPDATE', 'Contact'),
   contactsController.updateContact
 );
 
@@ -33,6 +36,7 @@ router.patch(
   '/:id/ban',
   authenticate,
   authorize(['MODERATOR', 'ADMIN']),
+  audit('BAN', 'Contact'),
   contactsController.banContact
 );
 


### PR DESCRIPTION
## Summary
- create middleware to record user actions via `auditService.logAction`
- hook audit middleware into create, update and ban routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68492a3394e08322a2fd91369bb28c0c