### PR TITLE
Remove unused audit service import

### DIFF
--- a/backend/src/services/contacts.service.js
+++ b/backend/src/services/contacts.service.js
@@ -1,18 +1,17 @@
-const contactRepository = require('../repositories/contact.repository');
-const auditService = require('./audit.service');
+const contactRepository = require('../repositories/contact.repository')
 
 exports.getContacts = async (options) => {
-  return await contactRepository.getContacts(options);
-};
+  return await contactRepository.getContacts(options)
+}
 
 exports.createContact = async (data) => {
-  return await contactRepository.createContact(data);
-};
+  return await contactRepository.createContact(data)
+}
 
 exports.updateContact = async (id, data) => {
-  return await contactRepository.updateContact(id, data);
-};
+  return await contactRepository.updateContact(id, data)
+}
 
 exports.banContact = async (id) => {
-  return await contactRepository.banContact(id);
-};
+  return await contactRepository.banContact(id)
+}


### PR DESCRIPTION
## Summary
- remove unused `auditService` from contacts service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npx prettier --write backend/src/services/contacts.service.js`

------
https://chatgpt.com/codex/tasks/task_e_68492f2bdb3483228146a703b9ac7ab6