### PR TITLE
Improve auth state init

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -1,14 +1,20 @@
-'use client';
+'use client'
 
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from 'react'
 
 type AuthContextType = {
-  token: string;
-  role: string;
-  isAuthenticated: boolean;
-  login: (token: string) => void;
-  logout: () => void;
-};
+  token: string
+  role: string
+  isAuthenticated: boolean
+  login: (token: string) => void
+  logout: () => void
+}
 
 const AuthContext = createContext<AuthContextType>({
   token: '',
@@ -16,46 +22,66 @@ const AuthContext = createContext<AuthContextType>({
   isAuthenticated: false,
   login: () => {},
   logout: () => {},
-});
+})
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const [token, setToken] = useState<string>('');
-  const [role, setRole] = useState<string>('');
-
-  useEffect(() => {
-    const storedToken = localStorage.getItem('token');
-    const storedRole = localStorage.getItem('role');
-
-    if (storedToken) setToken(storedToken);
-    if (storedRole) setRole(storedRole);
-  }, []);
-
-  const login = (newToken: string): string => {
-  const decoded = JSON.parse(atob(newToken.split('.')[1]));
-  const userRole = decoded.role;
-
-  localStorage.setItem('token', newToken);
-  localStorage.setItem('role', userRole);
-
-  setToken(newToken);
-  setRole(userRole);
-
-  return userRole; // 👈 muy importante para que LoginPage pueda redirigir
-};
+  const [token, setToken] = useState<string>('')
+  const [role, setRole] = useState<string>('')
 
   const logout = () => {
-    localStorage.removeItem('token');
-    localStorage.removeItem('role');
+    localStorage.removeItem('token')
+    localStorage.removeItem('role')
 
-    setToken('');
-    setRole('');
-  };
+    setToken('')
+    setRole('')
+  }
+
+  const login = (newToken: string): string => {
+    const decoded = JSON.parse(atob(newToken.split('.')[1]))
+    const userRole = decoded.role
+
+    localStorage.setItem('token', newToken)
+    localStorage.setItem('role', userRole)
+
+    setToken(newToken)
+    setRole(userRole)
+
+    return userRole // 👈 muy importante para que LoginPage pueda redirigir
+  }
+
+  useEffect(() => {
+    const storedToken = localStorage.getItem('token')
+    const storedRole = localStorage.getItem('role')
+
+    if (storedToken) {
+      try {
+        const decoded = JSON.parse(atob(storedToken.split('.')[1]))
+
+        if (decoded.exp && decoded.exp * 1000 < Date.now()) {
+          logout()
+          return
+        }
+
+        setToken(storedToken)
+
+        if (storedRole) {
+          setRole(storedRole)
+        } else if (decoded.role) {
+          setRole(decoded.role)
+        }
+      } catch {
+        logout()
+      }
+    }
+  }, [])
 
   return (
-    <AuthContext.Provider value={{ token, role, isAuthenticated: !!token, login, logout }}>
+    <AuthContext.Provider
+      value={{ token, role, isAuthenticated: !!token, login, logout }}
+    >
       {children}
     </AuthContext.Provider>
-  );
-};
+  )
+}
 
-export const useAuth = () => useContext(AuthContext);
+export const useAuth = () => useContext(AuthContext)


### PR DESCRIPTION
## Summary
- derive user role from login token
- store login helpers before effects
- when reading localStorage, decode token and logout on expiry

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run format` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68492f31bbec8322bb22e26e6ea88414