### PR TITLE
Use env variable for API URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -20,7 +20,9 @@ export default function ContactsPage() {
   useEffect(() => {
     const fetchContacts = async () => {
       setIsLoading(true);
-      const { data, ok, error } = await get('http://localhost:3000/contacts');
+      const { data, ok, error } = await get(
+        `${process.env.NEXT_PUBLIC_API_URL}/contacts`
+      );
 
       if (ok) {
         setContacts(data);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -19,7 +19,9 @@ export default function DashboardPage() {
   useEffect(() => {
     const fetchContacts = async () => {
       setIsLoading(true);
-      const { data, ok, error } = await get('http://localhost:3000/contacts');
+      const { data, ok, error } = await get(
+        `${process.env.NEXT_PUBLIC_API_URL}/contacts`
+      );
 
       if (ok) {
         setContacts(data);
@@ -34,14 +36,16 @@ export default function DashboardPage() {
 
   const handleBanContact = async (contactId: string | number) => {
     const { ok, error } = await post(
-      `http://localhost:3000/contacts/${contactId}/ban`,
+      `${process.env.NEXT_PUBLIC_API_URL}/contacts/${contactId}/ban`,
       {}
     );
 
     if (ok) {
       showToast('Contact banned', 'success');
       // Refetch contacts
-      const { data } = await get('http://localhost:3000/contacts');
+      const { data } = await get(
+        `${process.env.NEXT_PUBLIC_API_URL}/contacts`
+      );
       setContacts(data);
     } else {
       showToast(error || 'Failed to ban contact', 'error');

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -28,13 +28,16 @@ export default function LoginPage() {
     }
 
     try {
-      const response = await fetch('http://localhost:3000/auth/login', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, password }),
-      });
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/login`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ email, password }),
+        }
+      );
 
       const data = await response.json();
 


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_API_URL` to `.env`
- use `NEXT_PUBLIC_API_URL` in login, contacts and dashboard pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68492f3118f48322a2c49ceb6e33aecf