### PR TITLE
Implement DELETE endpoint for contacts

### DIFF
--- a/backend/src/config/swaggerSpec.js
+++ b/backend/src/config/swaggerSpec.js
@@ -13,16 +13,16 @@ const swaggerSpec = {
   tags: [
     {
       name: 'Authentication',
-      description: 'User authentication'
+      description: 'User authentication',
     },
     {
       name: 'Contacts',
-      description: 'Manage employee contacts'
+      description: 'Manage employee contacts',
     },
     {
       name: 'Audit Log',
-      description: 'Audit log entries'
-    }
+      description: 'Audit log entries',
+    },
   ],
   components: {
     securitySchemes: {
@@ -98,7 +98,14 @@ const swaggerSpec = {
       },
       AuditLog: {
         type: 'object',
-        required: ['id', 'action', 'entity', 'entityId', 'changedById', 'timestamp'],
+        required: [
+          'id',
+          'action',
+          'entity',
+          'entityId',
+          'changedById',
+          'timestamp',
+        ],
         properties: {
           id: { type: 'string' },
           action: { type: 'string' },
@@ -271,6 +278,30 @@ const swaggerSpec = {
           },
         },
       },
+      delete: {
+        security: [{ bearerAuth: [] }],
+        tags: ['Contacts'],
+        summary: 'Delete a contact',
+        parameters: [
+          {
+            in: 'path',
+            name: 'id',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          204: { description: 'Contact deleted' },
+          404: {
+            description: 'Contact not found',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Error' },
+              },
+            },
+          },
+        },
+      },
     },
     '/contacts/{id}/ban': {
       patch: {
@@ -326,6 +357,6 @@ const swaggerSpec = {
       },
     },
   },
-};
+}
 
-module.exports = swaggerSpec;
+module.exports = swaggerSpec

--- a/backend/src/controllers/contacts.controller.js
+++ b/backend/src/controllers/contacts.controller.js
@@ -1,82 +1,95 @@
-const contactsService = require('../services/contacts.service');
-const logger = require('../utils/logger');
+const contactsService = require('../services/contacts.service')
+const logger = require('../utils/logger')
 
 exports.getContacts = async (req, res, next) => {
   try {
-    const { page, limit, search, status } = req.query;
+    const { page, limit, search, status } = req.query
     const contacts = await contactsService.getContacts({
       page: Number(page) || 1,
       limit: Number(limit) || 10,
       search,
       status,
-    });
-    res.json(contacts);
+    })
+    res.json(contacts)
   } catch (err) {
-    logger.error(err);
-    next(err);
+    logger.error(err)
+    next(err)
   }
-};
+}
 
 exports.createContact = async (req, res, next) => {
   try {
-    const { name, email, phone } = req.body;
+    const { name, email, phone } = req.body
     if (!name || !email || !phone) {
-      return res.status(400).json({ error: 'Missing required fields' });
+      return res.status(400).json({ error: 'Missing required fields' })
     }
-    const contact = await contactsService.createContact(req.body);
-    res.status(201).json(contact);
+    const contact = await contactsService.createContact(req.body)
+    res.status(201).json(contact)
   } catch (err) {
-    logger.error(err);
-    next(err);
+    logger.error(err)
+    next(err)
   }
-};
+}
 
 exports.updateContact = async (req, res, next) => {
   try {
     const contact = await contactsService.updateContact(
       req.params.id,
       req.body,
-      req.user.id
-    );
-    res.json(contact);
+      req.user.id,
+    )
+    res.json(contact)
   } catch (err) {
-    logger.error(err);
-    next(err);
+    logger.error(err)
+    next(err)
   }
-};
+}
 
 exports.banContact = async (req, res, next) => {
   try {
-    const contact = await contactsService.banContact(req.params.id, req.user.id);
-    res.json(contact);
+    const contact = await contactsService.banContact(req.params.id, req.user.id)
+    res.json(contact)
   } catch (err) {
-    logger.error(err);
-    next(err);
+    logger.error(err)
+    next(err)
   }
-};
+}
 
 exports.updateContact = async (req, res, next) => {
   try {
-    const contact = await contactsService.updateContact(req.params.id, req.body);
-    res.json(contact);
+    const contact = await contactsService.updateContact(req.params.id, req.body)
+    res.json(contact)
   } catch (err) {
-    logger.error(err);
+    logger.error(err)
     if (err.code === 'P2025') {
-      return res.status(404).json({ error: 'Contact not found' });
+      return res.status(404).json({ error: 'Contact not found' })
     }
-    next(err);
+    next(err)
   }
-};
+}
 
 exports.banContact = async (req, res, next) => {
   try {
-    const contact = await contactsService.banContact(req.params.id);
-    res.json(contact);
+    const contact = await contactsService.banContact(req.params.id)
+    res.json(contact)
   } catch (err) {
-    logger.error(err);
+    logger.error(err)
     if (err.code === 'P2025') {
-      return res.status(404).json({ error: 'Contact not found' });
+      return res.status(404).json({ error: 'Contact not found' })
     }
-    next(err);
+    next(err)
   }
-};
+}
+
+exports.deleteContact = async (req, res, next) => {
+  try {
+    await contactsService.deleteContact(req.params.id)
+    res.status(204).end()
+  } catch (err) {
+    logger.error(err)
+    if (err.code === 'P2025') {
+      return res.status(404).json({ error: 'Contact not found' })
+    }
+    next(err)
+  }
+}

--- a/backend/src/repositories/contact.repository.js
+++ b/backend/src/repositories/contact.repository.js
@@ -1,37 +1,43 @@
-const { PrismaClient } = require('@prisma/client');
-const prisma = new PrismaClient();
+const { PrismaClient } = require('@prisma/client')
+const prisma = new PrismaClient()
 
 exports.getContacts = async ({ page = 1, limit = 10, search, status } = {}) => {
-  const where = {};
+  const where = {}
   if (search) {
     where.OR = [
       { name: { contains: search, mode: 'insensitive' } },
       { email: { contains: search, mode: 'insensitive' } },
-    ];
+    ]
   }
   if (status) {
-    where.status = status;
+    where.status = status
   }
-  const skip = (page - 1) * limit;
-  return await prisma.contact.findMany({ where, skip, take: limit });
-};
+  const skip = (page - 1) * limit
+  return await prisma.contact.findMany({ where, skip, take: limit })
+}
 
 exports.createContact = async (data) => {
   return await prisma.contact.create({
     data,
-  });
-};
+  })
+}
 
 exports.updateContact = async (id, data) => {
   return await prisma.contact.update({
     where: { id },
     data,
-  });
-};
+  })
+}
 
 exports.banContact = async (id) => {
   return await prisma.contact.update({
     where: { id },
     data: { status: 'BANNED' },
-  });
-};
+  })
+}
+
+exports.deleteContact = async (id) => {
+  return await prisma.contact.delete({
+    where: { id },
+  })
+}

--- a/backend/src/routes/contacts.routes.js
+++ b/backend/src/routes/contacts.routes.js
@@ -45,4 +45,12 @@ router.patch(
   contactsController.banContact,
 )
 
+router.delete(
+  '/:id',
+  authenticate,
+  authorize(['MODERATOR', 'ADMIN']),
+  validate(idParamSchema, 'params'),
+  contactsController.deleteContact,
+)
+
 module.exports = router

--- a/backend/src/services/contacts.service.js
+++ b/backend/src/services/contacts.service.js
@@ -1,18 +1,22 @@
-const contactRepository = require('../repositories/contact.repository');
-const auditService = require('./audit.service');
+const contactRepository = require('../repositories/contact.repository')
+const auditService = require('./audit.service')
 
 exports.getContacts = async (options) => {
-  return await contactRepository.getContacts(options);
-};
+  return await contactRepository.getContacts(options)
+}
 
 exports.createContact = async (data) => {
-  return await contactRepository.createContact(data);
-};
+  return await contactRepository.createContact(data)
+}
 
 exports.updateContact = async (id, data) => {
-  return await contactRepository.updateContact(id, data);
-};
+  return await contactRepository.updateContact(id, data)
+}
 
 exports.banContact = async (id) => {
-  return await contactRepository.banContact(id);
-};
+  return await contactRepository.banContact(id)
+}
+
+exports.deleteContact = async (id) => {
+  return await contactRepository.deleteContact(id)
+}


### PR DESCRIPTION
## Summary
- allow moderators/admins to delete contacts
- expose DELETE /contacts/:id route
- add service and repository logic for removing a contact
- document the new endpoint in Swagger spec

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68492f3343f883228b0b07c35549193f