### PR TITLE
Fix API hooks and fetch behaviour

### DIFF
--- a/src/app/contacts/page.test.tsx
+++ b/src/app/contacts/page.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import ContactsPage from './page';
+import { AuthContext } from '../context/AuthContext';
+
+vi.mock('../hooks/useProtectedRoute', () => ({
+  useProtectedRoute: () => {},
+}));
+
+vi.mock('../components/ToastProvider', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+const fetchMock = vi.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+);
+vi.stubGlobal('fetch', fetchMock);
+
+const Wrapper = (token: string) =>
+  function WrapperComponent({ children }: { children: React.ReactNode }) {
+    return (
+      <AuthContext.Provider
+        value={{
+          token,
+          role: 'ADMIN',
+          isAuthenticated: true,
+          isInitialized: true,
+          login: vi.fn(),
+          logout: vi.fn(),
+        }}
+      >
+        {children}
+      </AuthContext.Provider>
+    );
+  };
+
+describe('ContactsPage', () => {
+  it('fetches contacts only once with stable token', async () => {
+    render(
+      <React.StrictMode>
+        <ContactsPage />
+      </React.StrictMode>,
+      { wrapper: Wrapper('abc') }
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+});
+

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useApi } from '@/app/hooks/useApi';
 import { useProtectedRoute } from '@/app/hooks/useProtectedRoute';
 import { useToast } from '../components/ToastProvider';
+import { useAuth } from '../context/AuthContext';
 
 export default function ContactsPage() {
   // 👈 Proteges esta página → todos los roles pueden entrar
@@ -11,6 +12,7 @@ export default function ContactsPage() {
 
   const { get } = useApi();
   const { showToast } = useToast();
+  const { token } = useAuth();
 
   type Contact = { id: string | number; name: string; email: string };
 
@@ -33,7 +35,7 @@ export default function ContactsPage() {
     };
 
     fetchContacts();
-  }, [get]);
+  }, [token]);
 
   return (
     <div className="min-h-screen bg-gray-100 py-10 px-6">

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import DashboardPage from './page';
+import { AuthContext } from '../context/AuthContext';
+
+vi.mock('../hooks/useProtectedRoute', () => ({
+  useProtectedRoute: () => {},
+}));
+
+vi.mock('../components/ToastProvider', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+const fetchMock = vi.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+);
+vi.stubGlobal('fetch', fetchMock);
+
+const Wrapper = (token: string) =>
+  function WrapperComponent({ children }: { children: React.ReactNode }) {
+    return (
+      <AuthContext.Provider
+        value={{
+          token,
+          role: 'ADMIN',
+          isAuthenticated: true,
+          isInitialized: true,
+          login: vi.fn(),
+          logout: vi.fn(),
+        }}
+      >
+        {children}
+      </AuthContext.Provider>
+    );
+  };
+
+describe('DashboardPage', () => {
+  it('fetches contacts only once with stable token', async () => {
+    render(
+      <React.StrictMode>
+        <DashboardPage />
+      </React.StrictMode>,
+      { wrapper: Wrapper('abc') }
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+});
+

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,12 +4,14 @@ import { useEffect, useState } from 'react';
 import { useApi } from '@/app/hooks/useApi';
 import { useProtectedRoute } from '@/app/hooks/useProtectedRoute';
 import { useToast } from '../components/ToastProvider';
+import { useAuth } from '../context/AuthContext';
 
 export default function DashboardPage() {
   useProtectedRoute(['MODERATOR', 'ADMIN']); // 👈 Solo estos roles pueden entrar
 
   const { get, post } = useApi();
   const { showToast } = useToast();
+  const { token } = useAuth();
 
   type Contact = { id: string | number; name: string; email: string; status: string };
 
@@ -32,7 +34,7 @@ export default function DashboardPage() {
     };
 
     fetchContacts();
-  }, [get]);
+  }, [token]);
 
   const handleBanContact = async (contactId: string | number) => {
     const { ok, error } = await post(

--- a/src/app/hooks/useApi.ts
+++ b/src/app/hooks/useApi.ts
@@ -1,11 +1,12 @@
 'use client';
 
+import { useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
 
 export const useApi = () => {
   const { token } = useAuth();
 
-  const get = async (url: string) => {
+  const get = useCallback(async (url: string) => {
     try {
       const response = await fetch(url, {
         headers: {
@@ -25,9 +26,9 @@ export const useApi = () => {
       console.error('GET error:', error);
       return { data: null, ok: false, status: 0, error: 'Network error' };
     }
-  };
+  }, [token]);
 
-  const post = async (url: string, body: unknown) => {
+  const post = useCallback(async (url: string, body: unknown) => {
     try {
       const response = await fetch(url, {
         method: 'POST',
@@ -50,7 +51,7 @@ export const useApi = () => {
       console.error('POST error:', error);
       return { data: null, ok: false, status: 0, error: 'Network error' };
     }
-  };
+  }, [token]);
 
   return { get, post };
 };


### PR DESCRIPTION
## Summary
- wrap `useApi` calls with `useCallback`
- rework contacts and dashboard pages to watch the auth token
- test that contacts and dashboard only fetch once when rendered

## Testing
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e63218188322a1889e050fc5f079