### PR TITLE
Add backend env example and doc update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules
 # Keep environment variables out of version control
 .env
 .env.*
+!.env.example
+!backend/.env.example
 
 # Build directories
 .next

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Una plataforma interna para gestionar el directorio de empleados. **Roles: USER,
 ### 1️⃣ Backend
 
 ```bash
+cp backend/.env.example backend/.env
 cd backend
 npm install
-cp .env.example .env
 # Completa DATABASE_URL y JWT_SECRET
 
 # Generar Prisma Client

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+# Environment configuration for the backend
+# Fill these values in backend/.env before running the server
+
+DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/database"
+JWT_SECRET="change_this_secret"
+ALLOWED_ORIGIN="http://localhost:3001"


### PR DESCRIPTION
## Summary
- provide a `.env.example` file in `backend` with the basic env vars
- allow example env files in `.gitignore`
- update the setup instructions to copy the example env file before installing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e69263e8832291d1d103168789a5